### PR TITLE
GH-14: Switch upvote tracking to count and update database 

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,12 @@ async def on_ready():
     password = os.getenv("DB_PASSWORD")
     database = os.getenv("DB_NAME")
     bot.database = Database(host, port, user, password, database)
-    await bot.database.init_db()
+    try:
+        await bot.database.init_db()
+    except Exception as e:
+        log.critical(f"A critical error occurred while initializing the database: {e}")
+        await bot.close()
+        return
 
     await load_cogs()
     log.info(f"{bot.user} is ready!")


### PR DESCRIPTION
## Changes
**Database**
- Updated `upvotes` schema
- Added rudimentary migration system to migrate data to the new `upvotes` table, backs up old table to `migration_001_upvotes_backup`
- Wrapped `init_db()` call in a try / except statement to stop the bot if a critical error occurs during database initialization
- Refactored database functions to fit the new schema (`set_upvotes(self, showcase_id: int, count: int):`, `get_upvotes(self, showcase_id: int) -> int:`, `get_top_5_showcases(self) -> List[Dict]:`)

**Voting Cog**
- Refactored all calls to database functions to fit the new schema gh-14
