### PR TITLE
Fix twitter link regex capturing groups

### DIFF
--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -332,8 +332,8 @@ class Utils(commands.Cog):
                 continue
 
         twitter_patterns = [
-            r'https://(www\.)?twitter\.com/\S+',
-            r'https://(www\.)?x\.com/\S+',
+            r'https://(?:www\.)?twitter\.com/\S+',
+            r'https://(?:www\.)?x\.com/\S+',
             r'https://vxtwitter\.com/\S+',
             r'https://fxtwitter\.com/\S+',
             r'https://nitter\.net/\S+',


### PR DESCRIPTION
The bot currently fails to properly convert twitter and x links due to the `www.` getting captured in the initial regex. This change turns the `(www.)?` into a non-capturing group (`(?:www.)?`) to avoid this.